### PR TITLE
Add French interest rates

### DIFF
--- a/lib/legal_interest_strategies/data/strategies/FR.yml
+++ b/lib/legal_interest_strategies/data/strategies/FR.yml
@@ -1,0 +1,66 @@
+country_code: FR
+strategies:
+  - business: true
+    consumer: false
+    source: https://entreprendre.service-public.gouv.fr/vosdroits/F23211?lang=en, https://www.ecb.europa.eu/stats/policy_and_exchange_rates/key_ecb_interest_rates/html/index.en.html
+    rates:
+      - from_date: 1999-07-01
+        rate: 11.5
+      - from_date: 2000-01-01
+        rate: 12.0
+      - from_date: 2000-07-01
+        rate: 13.25
+      - from_date: 2001-01-01
+        rate: 13.75
+      - from_date: 2001-07-01
+        rate: 13.50
+      - from_date: 2002-01-01
+        rate: 12.25
+      - from_date: 2003-01-01
+        rate: 11.75
+      - from_date: 2003-07-01
+        rate: 11.0
+      - from_date: 2006-01-01
+        rate: 11.25
+      - from_date: 2006-07-01
+        rate: 11.75
+      - from_date: 2007-01-01
+        rate: 12.5
+      - from_date: 2007-07-01
+        rate: 13.0
+      - from_date: 2009-01-01
+        rate: 12.5
+      - from_date: 2009-07-01
+        rate: 11.0
+      - from_date: 2011-07-01
+        rate: 11.25
+      - from_date: 2013-01-01
+        rate: 10.75
+      - from_date: 2013-07-01
+        rate: 10.5
+      - from_date: 2014-01-01
+        rate: 10.25
+      - from_date: 2014-07-01
+        rate: 10.15
+      - from_date: 2015-01-01
+        rate: 10.05
+      - from_date: 2016-07-01
+        rate: 10.0
+      - from_date: 2023-01-01
+        rate: 12.5
+      - from_date: 2023-07-01
+        rate: 14.0
+      - from_date: 2024-01-01
+        rate: 14.50
+      - from_date: 2024-07-01
+        rate: 14.25
+      - from_date: 2025-01-01
+        rate: 13.15
+      - from_date: 2025-07-01
+        rate: 12.15
+  - business: false
+    consumer: true
+    source: https://www.service-public.gouv.fr/particuliers/vosdroits/F783?lang=en, court order needed
+    rates:
+      - from_date: 1999-07-01
+        rate: 0.0

--- a/spec/legal_interest_strategies_spec.rb
+++ b/spec/legal_interest_strategies_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LegalInterestStrategies do
     subject(:supported_country_codes) { described_class.supported_country_codes }
 
     it "returns an array of country codes" do
-      expect(supported_country_codes).to contain_exactly("BE", "NL")
+      expect(supported_country_codes).to contain_exactly("BE", "FR", "NL")
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/payt/legal_interest_strategies/issues/7

For consumers legal interest is only allowed when court is involved, therefore the interest in the gem is set to zero for our use case. There are alternatives like leaving it empty. But I prefer to keep tests in place that check for each country yml file that there is a consumer and a business strategy present.

- [ ] update gem on production