### PR TITLE
Update Dutch consumer interest

### DIFF
--- a/lib/legal_interest_strategies/data/strategies/NL.yml
+++ b/lib/legal_interest_strategies/data/strategies/NL.yml
@@ -172,3 +172,5 @@ strategies:
         rate: 7.0
       - from_date: 2025-01-01
         rate: 6.0
+      - from_date: 2026-01-01
+        rate: 4.0

--- a/spec/legal_interest_strategies_spec.rb
+++ b/spec/legal_interest_strategies_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe LegalInterestStrategies do
     end
 
     it "returns the right last consumer strategy rate" do
-      expect(consumer_rates_for_country.last).to eq({ from_date: Date.parse("2025-01-01"), rate: 6.0 })
+      expect(consumer_rates_for_country.last).to eq({ from_date: Date.parse("2026-01-01"), rate: 4.0 })
     end
 
     context "when there is no consumer strategy" do


### PR DESCRIPTION
References: https://github.com/payt/debiteurenbeheer/issues/22750

https://www.rijksoverheid.nl/onderwerpen/schulden/vraag-en-antwoord/hoogte-wettelijke-rente

<img width="847" height="238" alt="image" src="https://github.com/user-attachments/assets/084a1a8b-912f-45aa-a65a-ba68a488eb4b" />


For France and Belgium I could not find an updated interest rate.
