### PR TITLE
Update interest rates for second semester of 2026

### DIFF
--- a/lib/legal_interest_strategies/data/strategies/FR.yml
+++ b/lib/legal_interest_strategies/data/strategies/FR.yml
@@ -58,6 +58,8 @@ strategies:
         rate: 13.15
       - from_date: 2025-07-01
         rate: 12.15
+      - from_date: 2026-07-01
+        rate: 12.75
   - business: false
     consumer: true
     source: https://www.service-public.gouv.fr/particuliers/vosdroits/F783?lang=en, court order needed


### PR DESCRIPTION
BE and NL interest did not change.

For FR: https://entreprendre.service-public.gouv.fr/vosdroits/F23211?lang=en

- [ ] Needs update of the gem in debiteurenbeheer repo